### PR TITLE
Use a private node handle for everything.

### DIFF
--- a/include/image_publisher.h
+++ b/include/image_publisher.h
@@ -23,7 +23,7 @@ namespace Pylon
 
     ImagePublisher(ros::NodeHandle nh, sensor_msgs::CameraInfo::Ptr cinfo, string frame_id)
       : nh_(nh), it_(nh_) {
-      cam_pub_ = it_.advertiseCamera("camera/image_raw", 1);
+      cam_pub_ = it_.advertiseCamera("image_raw", 1);
       converter_.OutputPixelFormat = PixelType_RGB8packed;
       cinfo_ = cinfo;
       frame_id_ = frame_id;

--- a/src/basler_camera_node.cpp
+++ b/src/basler_camera_node.cpp
@@ -14,24 +14,23 @@ using namespace Pylon;
 int main(int argc, char* argv[])
 {
   ros::init(argc, argv, "basler_camera");
-  ros::NodeHandle nh;
-  ros::NodeHandle priv_nh("~");
+  ros::NodeHandle nh("~");
   camera_info_manager::CameraInfoManager cinfo_manager_(nh);
 
   int frame_rate;
-  if( !priv_nh.getParam("frame_rate", frame_rate) )
+  if( !nh.getParam("frame_rate", frame_rate) )
     frame_rate = 20;
 
   string camera_info_url;
-  if( !priv_nh.getParam("camera_info_url", camera_info_url) )
+  if( !nh.getParam("camera_info_url", camera_info_url) )
     camera_info_url = "";
 
   string frame_id;
-  if( !priv_nh.getParam("frame_id", frame_id) )
+  if( !nh.getParam("frame_id", frame_id) )
     frame_id = "";
 
   std::string serial_number;
-  if( !priv_nh.getParam("serial_number", serial_number) )
+  if( !nh.getParam("serial_number", serial_number) )
     serial_number = "";
 
   int exitCode = 0;


### PR DESCRIPTION
This makes it possible to use the driver multiple times with different names for different cameras. This is needed for example for the stereo_image_proc pipeline. The hard coded `camera` prefix requires a lot of manual remappings for the same effect.

This is a breaking change since it changes the default topic name from `camera/image_raw` to `basler_camera/image_raw`. However this pull request gives full control over the name of the topics, which also enables easy use with `stereo_image_proc` and other ROS pipelines.

The topic naming used by this pull request is also how `usb_cam` does it (although the wiki page is outdated and claims a different scheme), which is probably how most people expect camera drivers to behave.
