### PR TITLE
Add boolean parameter handling

### DIFF
--- a/config/basler_params.yaml
+++ b/config/basler_params.yaml
@@ -4,6 +4,10 @@ basler_params:
     type: float
     value: 30.0
   -
+    name: AcquisitionFrameRateEnable
+    type: boolean
+    value: true
+  -
     name: AcquisitionMode
     type: enum
     value: Continuous

--- a/src/basler_camera_node.cpp
+++ b/src/basler_camera_node.cpp
@@ -104,7 +104,7 @@ void handle_basler_parameter(CInstantCamera& camera, XmlRpc::XmlRpcValue& param)
   string type = param["type"];
   if ("boolean" == type)
   {
-    ROS_ASSERT_MSG(param["value"].getType() == XmlRpcValue::TypeBoolean,
+    ROS_ASSERT_MSG(param["value"].getType() == XmlRpc::XmlRpcValue::TypeBoolean,
                    "Type of value for %s must be boolean", string(param["name"]).c_str());
     handle_basler_boolean_parameter(camera, param["name"], param["value"]);
   }


### PR DESCRIPTION
The Basler acA3800-14uc does not act on the AcquisitionFrameRate parameter
unless the AcquisitionFrameRateEnable parameter is set to True. This patch
allows setting boolean parameters with the same interface as int, enum, and
float. An example parameter for testing was added to basler_params.yaml.

This may be a partial fix for #5
